### PR TITLE
Feat implement message option dialog widget

### DIFF
--- a/lib/ui/views/home/home_view.dart
+++ b/lib/ui/views/home/home_view.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:stacked/stacked.dart';
 import 'package:zc_desktop_flutter/ui/appbar/app_bar.dart';
 import 'package:zc_desktop_flutter/ui/views/widgets/center_list_tile/center_tile.dart';
+import 'package:zc_desktop_flutter/ui/views/widgets/popup_menuitem.dart';
+
 import 'home_viewmodel.dart';
 
 class HomeView extends StatelessWidget {
@@ -16,13 +17,14 @@ class HomeView extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Container(child: buildAppBar(context, true)),
+            buildMenuItem(context),
             Expanded(
                 child: Container(
                     alignment: Alignment.topCenter,
                     child: centertitlecard(context))),
-                     ],
-          ),
+          ],
         ),
+      ),
       viewModelBuilder: () => HomeViewModel(),
     );
   }

--- a/lib/ui/views/widgets/popup_menuitem.dart
+++ b/lib/ui/views/widgets/popup_menuitem.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+
+PopupMenuButton buildMenuItem(BuildContext context) {
+  return PopupMenuButton(
+    itemBuilder: (context) => [
+      PopupMenuItem<int>(
+        value: 0,
+        child: Text(
+          'Turn off notifications for replies',
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 13,
+          ),
+        ),
+      ),
+      PopupMenuItem<int>(
+        value: 1,
+        child: Row(
+          children: [
+            Text(
+              'Mark Unread',
+              style: TextStyle(
+                color: Colors.black,
+                fontSize: 13,
+              ),
+            ),
+            SizedBox(width: 150),
+            Icon(
+              Icons.format_underline,
+              size: 15,
+            ),
+          ],
+        ),
+      ),
+      PopupMenuItem<int>(
+        value: 2,
+        child: Row(
+          children: [
+            Text(
+              'Remind me about this',
+              style: TextStyle(
+                color: Colors.black,
+                fontSize: 13,
+              ),
+            ),
+            SizedBox(width: 100),
+            Icon(
+              Icons.navigate_next_outlined,
+              size: 15,
+            ),
+          ],
+        ),
+      ),
+      PopupMenuItem<int>(
+        value: 3,
+        child: Text(
+          'Copy link',
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 13,
+          ),
+        ),
+      ),
+      PopupMenuItem<int>(
+        value: 4,
+        child: Row(
+          children: [
+            Text(
+              'Pin to this conversation',
+              style: TextStyle(
+                color: Colors.black,
+                fontSize: 13,
+              ),
+            ),
+            SizedBox(width: 90),
+            Icon(
+              Icons.push_pin_outlined,
+              size: 15,
+            ),
+          ],
+        ),
+      ),
+      PopupMenuItem<int>(
+        value: 5,
+        child: Text(
+          'Turn question into poll',
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 13,
+          ),
+        ),
+      ),
+      PopupMenuItem<int>(
+        value: 6,
+        child: Row(
+          children: [
+            Text(
+              'More message shortcuts',
+              style: TextStyle(
+                color: Colors.black,
+                fontSize: 13,
+              ),
+            ),
+            SizedBox(width: 83),
+            Icon(
+              Icons.launch,
+              size: 15,
+            ),
+          ],
+        ),
+      ),
+    ],
+    onSelected: (item) => SelectedItem(context, item),
+  );
+}
+
+SelectedItem(BuildContext context, item) {
+  switch (item) {
+    case 0:
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Turn off notification pressed')));
+      break;
+    case 1:
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Mark unread pressed')));
+      break;
+    case 2:
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(' Remind me about this pressed')));
+      break;
+    case 3:
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Copy pressed')));
+      break;
+    case 4:
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Pin to this conversation pressed')));
+      break;
+    case 5:
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Turn question into poll pressed')));
+      break;
+    case 6:
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('More message shortcuts pressed')));
+      break;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   bitsdojo_window:
     dependency: "direct main"
     description:
@@ -351,7 +351,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -629,7 +629,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
Message option dialog gives the users the ability to customize their messaging box.

This implementation adds all these options needed to have, to improve user experience in the app, and closes this issue #295 

- [x] Turn off notifications for replies
- [x] Mark unread 
- [x] Remind me about this   
- [x] Copy link  
- [x] Pin to this conversation   
- [x] Turn question into poll  
- [x] More message shortcuts


### **Video Preview**

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/70817641/131949726-73ea7e43-54e3-4129-99dd-87ae1837be3f.gif)


### **Screenshot Preview**

![image](https://user-images.githubusercontent.com/70817641/131939262-968dbaf6-2369-4c72-ae1f-f7d118b50402.png)

  


