### PR TITLE
#324 -  Message Draft Widget fixes issue #324

### DIFF
--- a/lib/ui/views/draft/draft_model.dart
+++ b/lib/ui/views/draft/draft_model.dart
@@ -1,0 +1,11 @@
+import 'package:intl/intl.dart';
+
+class Draft {
+  String subject = "";
+  String content = "";
+  DateTime date = DateTime.now();
+  String getFormattedDate() =>
+      '${DateFormat("MMM dd").format(this.date)} at ${DateFormat("h:mm a").format(this.date)}';
+  Draft._();
+  Draft(this.subject, this.content, this.date);
+}

--- a/lib/ui/views/draft/draft_view.dart
+++ b/lib/ui/views/draft/draft_view.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+import 'draft_viewmodel.dart';
+
+class DraftView extends StatelessWidget {
+  const DraftView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const double iconSize = 12;
+    const iconPadding = EdgeInsets.all(5);
+    const iconConstraint = BoxConstraints();
+    return ViewModelBuilder<DraftViewModel>.reactive(
+      builder: (context, model, child) => Scaffold(
+        appBar: AppBar(
+          title: Text(model.title),
+        ),
+        body: Column(
+          children: [
+            Expanded(
+              child: ListView.builder(
+                  itemCount: model.drafts.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    var draft = model.drafts[index];
+
+                    return Card(
+                      elevation: 2.0,
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Column(children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  draft.subject,
+                                  style: TextStyle(fontWeight: FontWeight.bold),
+                                ),
+                                flex: 3,
+                              ),
+                              Expanded(
+                                child: Text(
+                                  draft.getFormattedDate(),
+                                  textAlign: TextAlign.right,
+                                  style: TextStyle(
+                                      fontSize: 11.5,
+                                      fontWeight: FontWeight.normal),
+                                ),
+                                flex: 1,
+                              ),
+                            ],
+                          ),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  draft.content,
+                                ),
+                              ),
+                              SizedBox(
+                                height: 20,
+                                width: 120,
+
+                                // size: Size(120, 20),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    IconButton(
+                                        iconSize: iconSize,
+                                        icon: const Icon(Icons.delete_outline),
+                                        tooltip: 'Delete Draft',
+                                        padding: iconPadding,
+                                        alignment: Alignment.center,
+                                        constraints: iconConstraint,
+                                        onPressed: () {}),
+                                    IconButton(
+                                      iconSize: iconSize,
+                                      icon: const Icon(Icons.edit_outlined),
+                                      tooltip: 'Edit Draft',
+                                      padding: iconPadding,
+                                      alignment: Alignment.center,
+                                      constraints: iconConstraint,
+                                      onPressed: () {},
+                                    ),
+                                    IconButton(
+                                      constraints: iconConstraint,
+                                      iconSize: iconSize,
+                                      icon: const Icon(Icons.send_outlined),
+                                      tooltip: 'Send Message',
+                                      padding: iconPadding,
+                                      alignment: Alignment.center,
+                                      onPressed: () {},
+                                    ),
+                                  ],
+                                ),
+                              )
+                            ],
+                          ),
+                        ]),
+                      ),
+                    );
+                  }),
+            )
+          ],
+        ),
+      ),
+      viewModelBuilder: () => DraftViewModel(),
+    );
+  }
+}

--- a/lib/ui/views/draft/draft_viewmodel.dart
+++ b/lib/ui/views/draft/draft_viewmodel.dart
@@ -1,0 +1,13 @@
+import 'package:stacked/stacked.dart';
+import 'package:zc_desktop_flutter/app/app.logger.dart';
+import 'draft_model.dart';
+
+class DraftViewModel extends BaseViewModel {
+  final log = getLogger("DraftViewwModel");
+  final title = 'Drafts';
+  List<Draft> drafts = <Draft>[
+    Draft("Tobi", "Zay is due for a raise, he has earned it!", DateTime.now()),
+    Draft("Tobi", "Koko is to make a push today", DateTime.now()),
+    Draft("Ope", "I will work on the landing page design tomorrow", DateTime.now())
+  ];
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,6 +261,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -496,7 +496,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -559,7 +559,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: ^0.17.0
   cupertino_icons: ^1.0.2
   # ui package for the whole app
   zcdesk_ui:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:zc_desktop_flutter/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(ZcDesktop());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
Message draft widget view displays the list of unsent messages (drafts) as indicated in issue #324 and shows the delete, edit and send icon button for the user to interact with the draft message.


https://user-images.githubusercontent.com/79860473/132103891-d6a82115-dd0f-484a-a36e-0e171e496111.mp4



 