### PR TITLE
completed message draft view to resolve issue #324.

### DIFF
--- a/lib/ui/views/draft/draft_model.dart
+++ b/lib/ui/views/draft/draft_model.dart
@@ -1,0 +1,12 @@
+import 'package:intl/intl.dart';
+
+//The intl package needs to be added to use date formatter
+class Draft {
+  String subject = "";
+  String content = "";
+  DateTime date = DateTime.now();
+  String getFormattedDate() =>
+      '${DateFormat("MMM dd").format(this.date)} at ${DateFormat("h:mm a").format(this.date)}';
+  Draft._();
+  Draft(this.subject, this.content, this.date);
+}

--- a/lib/ui/views/draft/draft_view.dart
+++ b/lib/ui/views/draft/draft_view.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+import 'draft_viewmodel.dart';
+
+class DraftView extends StatelessWidget {
+  const DraftView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const double iconSize = 12;
+    const iconPadding = EdgeInsets.all(5);
+    const iconConstraint = BoxConstraints();
+    return ViewModelBuilder<DraftViewModel>.reactive(
+      builder: (context, model, child) => Scaffold(
+        appBar: AppBar(
+          title: Text(model.title),
+        ),
+        body: Column(
+          children: [
+            Expanded(
+              child: ListView.builder(
+                  itemCount: model.drafts.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    var draft = model.drafts[index];
+
+                    return Card(
+                      elevation: 2.0,
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Column(children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  draft.subject,
+                                  style: TextStyle(fontWeight: FontWeight.bold),
+                                ),
+                                flex: 3,
+                              ),
+                              Expanded(
+                                child: Text(
+                                  draft.getFormattedDate(),
+                                  textAlign: TextAlign.right,
+                                  style: TextStyle(
+                                      fontSize: 11.5,
+                                      fontWeight: FontWeight.normal),
+                                ),
+                                flex: 1,
+                              ),
+                            ],
+                          ),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  draft.content,
+                                ),
+                              ),
+                              SizedBox(
+                                height: 20,
+                                width: 120,
+
+                                // size: Size(120, 20),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    IconButton(
+                                        iconSize: iconSize,
+                                        icon: const Icon(Icons.delete_outline),
+                                        tooltip: 'Delete Draft',
+                                        padding: iconPadding,
+                                        alignment: Alignment.center,
+                                        constraints: iconConstraint,
+                                        onPressed: () {}),
+                                    IconButton(
+                                      iconSize: iconSize,
+                                      icon: const Icon(Icons.edit_outlined),
+                                      tooltip: 'Edit Draft',
+                                      padding: iconPadding,
+                                      alignment: Alignment.center,
+                                      constraints: iconConstraint,
+                                      onPressed: () {},
+                                    ),
+                                    IconButton(
+                                      constraints: iconConstraint,
+                                      iconSize: iconSize,
+                                      icon: const Icon(Icons.send_outlined),
+                                      tooltip: 'Send Message',
+                                      padding: iconPadding,
+                                      alignment: Alignment.center,
+                                      onPressed: () {},
+                                    ),
+                                  ],
+                                ),
+                              )
+                            ],
+                          ),
+                        ]),
+                      ),
+                    );
+                  }),
+            )
+          ],
+        ),
+      ),
+      viewModelBuilder: () => DraftViewModel(),
+    );
+  }
+}

--- a/lib/ui/views/draft/draft_viewmodel.dart
+++ b/lib/ui/views/draft/draft_viewmodel.dart
@@ -1,0 +1,13 @@
+import 'package:stacked/stacked.dart';
+import 'package:zc_desktop_flutter/app/app.logger.dart';
+import 'draft_model.dart';
+
+class DraftViewModel extends BaseViewModel {
+  final log = getLogger("DraftViewwModel");
+  final title = 'Drafts';
+  List<Draft> drafts = <Draft>[
+    Draft("Tobi", "Zay is due for a raise, he has earned it!", DateTime.now()),
+    Draft("Tobi", "Koko is to make a push today", DateTime.now()),
+    Draft("Ope", "I will work on the landing page design tomorrow", DateTime.now())
+  ];
+}


### PR DESCRIPTION
Message draft widget view displays the list of unsent messages (drafts) as indicated in issue #324 and shows the delete, edit and send icon button for the user to interact with the draft message.


https://user-images.githubusercontent.com/79860473/132103891-d6a82115-dd0f-484a-a36e-0e171e496111.mp4
